### PR TITLE
Lcvw 36 robar carta y mock de repartir cartas

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,6 @@
 	</head>
 	<body>
 		<div id="root"></div>
-		<script type="module" src="/src/main.jsx"></script>
+		<script type="module" src="/src/Game.jsx"></script>
 	</body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,6 @@
 	</head>
 	<body>
 		<div id="root"></div>
-		<script type="module" src="/src/Game.jsx"></script>
+		<script type="module" src="/src/main.jsx"></script>
 	</body>
 </html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,5 +48,8 @@
 		"prettier": "^3.0.3",
 		"react-router-dom": "^6.16.0",
 		"vite": "^4.4.5"
+	},
+	"msw": {
+		"workerDirectory": "public"
 	}
 }

--- a/frontend/public/mockServiceWorker.js
+++ b/frontend/public/mockServiceWorker.js
@@ -1,0 +1,302 @@
+/* tslint:disable */
+
+/**
+ * Mock Service Worker (1.3.1).
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ * - Please do NOT serve this file on production.
+ */
+
+const INTEGRITY_CHECKSUM = '3d6b9f06410d179a7f7404d4bf4c3c70';
+const activeClientIds = new Set();
+
+self.addEventListener('install', function () {
+	self.skipWaiting();
+});
+
+self.addEventListener('activate', function (event) {
+	event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('message', async function (event) {
+	const clientId = event.source.id;
+
+	if (!clientId || !self.clients) {
+		return;
+	}
+
+	const client = await self.clients.get(clientId);
+
+	if (!client) {
+		return;
+	}
+
+	const allClients = await self.clients.matchAll({
+		type: 'window',
+	});
+
+	switch (event.data) {
+		case 'KEEPALIVE_REQUEST': {
+			sendToClient(client, {
+				type: 'KEEPALIVE_RESPONSE',
+			});
+			break;
+		}
+
+		case 'INTEGRITY_CHECK_REQUEST': {
+			sendToClient(client, {
+				type: 'INTEGRITY_CHECK_RESPONSE',
+				payload: INTEGRITY_CHECKSUM,
+			});
+			break;
+		}
+
+		case 'MOCK_ACTIVATE': {
+			activeClientIds.add(clientId);
+
+			sendToClient(client, {
+				type: 'MOCKING_ENABLED',
+				payload: true,
+			});
+			break;
+		}
+
+		case 'MOCK_DEACTIVATE': {
+			activeClientIds.delete(clientId);
+			break;
+		}
+
+		case 'CLIENT_CLOSED': {
+			activeClientIds.delete(clientId);
+
+			const remainingClients = allClients.filter((client) => {
+				return client.id !== clientId;
+			});
+
+			// Unregister itself when there are no more clients
+			if (remainingClients.length === 0) {
+				self.registration.unregister();
+			}
+
+			break;
+		}
+	}
+});
+
+self.addEventListener('fetch', function (event) {
+	const {request} = event;
+	const accept = request.headers.get('accept') || '';
+
+	// Bypass server-sent events.
+	if (accept.includes('text/event-stream')) {
+		return;
+	}
+
+	// Bypass navigation requests.
+	if (request.mode === 'navigate') {
+		return;
+	}
+
+	// Opening the DevTools triggers the "only-if-cached" request
+	// that cannot be handled by the worker. Bypass such requests.
+	if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+		return;
+	}
+
+	// Bypass all requests when there are no active clients.
+	// Prevents the self-unregistered worked from handling requests
+	// after it's been deleted (still remains active until the next reload).
+	if (activeClientIds.size === 0) {
+		return;
+	}
+
+	// Generate unique request ID.
+	const requestId = Math.random().toString(16).slice(2);
+
+	event.respondWith(
+		handleRequest(event, requestId).catch((error) => {
+			if (error.name === 'NetworkError') {
+				console.warn(
+					'[MSW] Successfully emulated a network error for the "%s %s" request.',
+					request.method,
+					request.url,
+				);
+				return;
+			}
+
+			// At this point, any exception indicates an issue with the original request/response.
+			console.error(
+				`\
+[MSW] Caught an exception from the "%s %s" request (%s). This is probably not a problem with Mock Service Worker. There is likely an additional logging output above.`,
+				request.method,
+				request.url,
+				`${error.name}: ${error.message}`,
+			);
+		}),
+	);
+});
+
+async function handleRequest(event, requestId) {
+	const client = await resolveMainClient(event);
+	const response = await getResponse(event, client, requestId);
+
+	// Send back the response clone for the "response:*" life-cycle events.
+	// Ensure MSW is active and ready to handle the message, otherwise
+	// this message will pend indefinitely.
+	if (client && activeClientIds.has(client.id)) {
+		(async function () {
+			const clonedResponse = response.clone();
+			sendToClient(client, {
+				type: 'RESPONSE',
+				payload: {
+					requestId,
+					type: clonedResponse.type,
+					ok: clonedResponse.ok,
+					status: clonedResponse.status,
+					statusText: clonedResponse.statusText,
+					body:
+						clonedResponse.body === null ? null : await clonedResponse.text(),
+					headers: Object.fromEntries(clonedResponse.headers.entries()),
+					redirected: clonedResponse.redirected,
+				},
+			});
+		})();
+	}
+
+	return response;
+}
+
+// Resolve the main client for the given event.
+// Client that issues a request doesn't necessarily equal the client
+// that registered the worker. It's with the latter the worker should
+// communicate with during the response resolving phase.
+async function resolveMainClient(event) {
+	const client = await self.clients.get(event.clientId);
+
+	if (client?.frameType === 'top-level') {
+		return client;
+	}
+
+	const allClients = await self.clients.matchAll({
+		type: 'window',
+	});
+
+	return allClients
+		.filter((client) => {
+			// Get only those clients that are currently visible.
+			return client.visibilityState === 'visible';
+		})
+		.find((client) => {
+			// Find the client ID that's recorded in the
+			// set of clients that have registered the worker.
+			return activeClientIds.has(client.id);
+		});
+}
+
+async function getResponse(event, client, requestId) {
+	const {request} = event;
+	const clonedRequest = request.clone();
+
+	function passthrough() {
+		// Clone the request because it might've been already used
+		// (i.e. its body has been read and sent to the client).
+		const headers = Object.fromEntries(clonedRequest.headers.entries());
+
+		// Remove MSW-specific request headers so the bypassed requests
+		// comply with the server's CORS preflight check.
+		// Operate with the headers as an object because request "Headers"
+		// are immutable.
+		delete headers['x-msw-bypass'];
+
+		return fetch(clonedRequest, {headers});
+	}
+
+	// Bypass mocking when the client is not active.
+	if (!client) {
+		return passthrough();
+	}
+
+	// Bypass initial page load requests (i.e. static assets).
+	// The absence of the immediate/parent client in the map of the active clients
+	// means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+	// and is not ready to handle requests.
+	if (!activeClientIds.has(client.id)) {
+		return passthrough();
+	}
+
+	// Bypass requests with the explicit bypass header.
+	// Such requests can be issued by "ctx.fetch()".
+	if (request.headers.get('x-msw-bypass') === 'true') {
+		return passthrough();
+	}
+
+	// Notify the client that a request has been intercepted.
+	const clientMessage = await sendToClient(client, {
+		type: 'REQUEST',
+		payload: {
+			id: requestId,
+			url: request.url,
+			method: request.method,
+			headers: Object.fromEntries(request.headers.entries()),
+			cache: request.cache,
+			mode: request.mode,
+			credentials: request.credentials,
+			destination: request.destination,
+			integrity: request.integrity,
+			redirect: request.redirect,
+			referrer: request.referrer,
+			referrerPolicy: request.referrerPolicy,
+			body: await request.text(),
+			bodyUsed: request.bodyUsed,
+			keepalive: request.keepalive,
+		},
+	});
+
+	switch (clientMessage.type) {
+		case 'MOCK_RESPONSE': {
+			return respondWithMock(clientMessage.data);
+		}
+
+		case 'MOCK_NOT_FOUND': {
+			return passthrough();
+		}
+
+		case 'NETWORK_ERROR': {
+			const {name, message} = clientMessage.data;
+			const networkError = new Error(message);
+			networkError.name = name;
+
+			// Rejecting a "respondWith" promise emulates a network error.
+			throw networkError;
+		}
+	}
+
+	return passthrough();
+}
+
+function sendToClient(client, message) {
+	return new Promise((resolve, reject) => {
+		const channel = new MessageChannel();
+
+		channel.port1.onmessage = (event) => {
+			if (event.data && event.data.error) {
+				return reject(event.data.error);
+			}
+
+			resolve(event.data);
+		};
+
+		client.postMessage(message, [channel.port2]);
+	});
+}
+
+function sleep(timeMs) {
+	return new Promise((resolve) => {
+		setTimeout(resolve, timeMs);
+	});
+}
+
+async function respondWithMock(response) {
+	await sleep(response.delay);
+	return new Response(response.body, response);
+}

--- a/frontend/src/Game.jsx
+++ b/frontend/src/Game.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+// import App from './App.jsx';
+import {Provider} from 'react-redux';
+import store from './store/store.js';
+
+import Deck from './components/Deck/Deck.jsx';
+import Hand from './components/Hand/Hand.jsx';
+
+// import './mocks/server.js';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+	<React.StrictMode>
+		<Provider store={store}>
+			<Deck />
+			<Hand />
+		</Provider>
+	</React.StrictMode>,
+);

--- a/frontend/src/appActions.js
+++ b/frontend/src/appActions.js
@@ -3,3 +3,5 @@ import {createAction} from '@reduxjs/toolkit';
 // Definiciones de acciones
 export const setPlayerName = createAction('player/setName');
 export const setPlayerId = createAction('player/setId');
+export const setHand = createAction('hand/setHand');
+export const appendToHand = createAction('hand/appendToHand');

--- a/frontend/src/components/Card/Card.jsx
+++ b/frontend/src/components/Card/Card.jsx
@@ -1,16 +1,14 @@
 import PropTypes from 'prop-types';
 import './Card.css';
 
-const Card = ({token}) => {
-	console.log(token);
-	console.log(typeof token);
-
+const Card = ({onClick, token}) => {
 	return (
 		<button className='card-button'>
 			<img
 				className='card-image'
 				src={`src/assets/cards/${token}.jpg`}
 				alt='card'
+				onClick={onClick}
 			/>
 		</button>
 	);
@@ -18,7 +16,7 @@ const Card = ({token}) => {
 
 Card.propTypes = {
 	token: PropTypes.string.isRequired,
-	onclick: PropTypes.func,
+	onClick: PropTypes.func,
 };
 
 export default Card;

--- a/frontend/src/components/Deck/Deck.jsx
+++ b/frontend/src/components/Deck/Deck.jsx
@@ -1,0 +1,73 @@
+import Card from '../Card/Card.jsx';
+import {useEffect, useState} from 'react';
+import {useDispatch} from 'react-redux';
+import {appendToHand} from '../../services/handSlice';
+
+const Deck = () => {
+	const [clicked, setClicked] = useState(false);
+	const [imageSrc, setImageSrc] = useState([]);
+	const dispatch = useDispatch();
+
+	// inicializar el mazo con el primer fetch
+	const mockInitGet = JSON.parse(
+		JSON.stringify({
+			status: '',
+			message: '',
+			data: ['img65'],
+		}),
+	);
+
+	const mockPick = JSON.parse(
+		JSON.stringify({
+			status: '',
+			message: '',
+			data: ['img197'],
+		}),
+	);
+
+	// when component mounts
+	useEffect(() => {
+		const fetchCard = async () => {
+			// fetch back of first card in deck as initial state
+			// image is hardcoded because http request does not work
+			setImageSrc(mockInitGet.data[0]);
+		};
+		fetchCard();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	// when deck is clicked
+	const handleClick = () => {
+		// try {
+		// 	// fetches the next card in deck
+		// 	const response = await fetch('http://localhost:8000/hand/', {
+		// 		method: 'PUT',
+		// 	});
+		// 	setImageSrc(response.json().data);
+		// } catch (error) {
+		// 	console.error("Error fetching player's hand:", error);
+		// }
+
+		// if it wasn't clicked already
+		if (!clicked) {
+			// display first hand
+			setImageSrc(mockPick.data[0]);
+			// wait and update player's hand with picked card
+			setTimeout(() => {
+				dispatch(appendToHand(mockPick.data));
+				// display back of next card in deck
+				setImageSrc(mockInitGet.data[0]);
+			}, 1000);
+			// set clicked to true to avoid infinite picking of cards
+			setClicked(true);
+		}
+	};
+
+	return (
+		<div className='deck'>
+			<Card onClick={handleClick} token={imageSrc} />
+		</div>
+	);
+};
+
+export default Deck;

--- a/frontend/src/components/Hand/Hand.jsx
+++ b/frontend/src/components/Hand/Hand.jsx
@@ -5,7 +5,11 @@ import Card from '../../components/Card/Card.jsx';
 
 // mock format of json response. Player's hand is an array of card tokens
 const mock = JSON.parse(
-	'{"status": "", "message": "","data": ["img37", "img40","img72"]}',
+	JSON.stringify({
+		status: '',
+		message: '',
+		data: ['img37', 'img40', 'img72', 'img78'],
+	}),
 );
 
 const Hand = () => {

--- a/frontend/src/components/Hand/Hand.jsx
+++ b/frontend/src/components/Hand/Hand.jsx
@@ -1,7 +1,9 @@
 import './Hand.css';
-
-import {useEffect, useState} from 'react';
 import Card from '../../components/Card/Card.jsx';
+
+import {useEffect} from 'react';
+import {useDispatch, useSelector} from 'react-redux';
+import {setHand} from '../../services/handSlice';
 
 // mock format of json response. Player's hand is an array of card tokens
 const mock = JSON.parse(
@@ -12,26 +14,36 @@ const mock = JSON.parse(
 	}),
 );
 
+// represents a player's hand
 const Hand = () => {
-	// save the player's hand as an array
-	const [cards, setCards] = useState([]);
+	// select cards state
+	const cards = useSelector((state) => state.hand.cards);
+	const dispatch = useDispatch();
 
+	// when component mounts
 	useEffect(() => {
-		// const fetchHand = async () => {
-		// 	try {
-		// 		// fetches the player's hand
-		// 		const response = await fetch('http://localhost:8000/hand/', {
-		// 			method: 'GET'
-		// 		});
-		// 		setCards(response.json().data);
-		// 	} catch (error) {
-		// 		console.error("Error fetching player's hand:", error);
-		// 	}
-		// };
-		// fetchHand();
-		setCards(mock.data);
-	}, []);
+		// fetch  player's hand
+		const fetchHand = async () => {
+			try {
+				const response = await fetch('/cards', {
+					method: 'GET',
+					headers: {
+						'Content-Type': 'application/json',
+					},
+				});
+				const res = await response.json();
+				// set player's hand state using redux
+				dispatch(setHand(res.data));
+			} catch (error) {
+				console.error("Error fetching player's hand:", error);
+			}
+			// dispatch is hardcoded because http request does not work at the moment
+			dispatch(setHand(mock.data));
+		};
+		fetchHand();
+	}, [dispatch]);
 
+	// render cards in hand side by side
 	return (
 		<div className='hand'>
 			{cards.map((card) => (

--- a/frontend/src/components/Hand/Hand.jsx
+++ b/frontend/src/components/Hand/Hand.jsx
@@ -5,15 +5,6 @@ import {useEffect} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {setHand} from '../../services/handSlice';
 
-// mock format of json response. Player's hand is an array of card tokens
-const mock = JSON.parse(
-	JSON.stringify({
-		status: '',
-		message: '',
-		data: ['img37', 'img40', 'img72', 'img78'],
-	}),
-);
-
 // represents a player's hand
 const Hand = () => {
 	// select cards state
@@ -25,7 +16,7 @@ const Hand = () => {
 		// fetch  player's hand
 		const fetchHand = async () => {
 			try {
-				const response = await fetch('/cards', {
+				const response = await fetch('/hand', {
 					method: 'GET',
 					headers: {
 						'Content-Type': 'application/json',
@@ -37,8 +28,6 @@ const Hand = () => {
 			} catch (error) {
 				console.error("Error fetching player's hand:", error);
 			}
-			// dispatch is hardcoded because http request does not work at the moment
-			dispatch(setHand(mock.data));
 		};
 		fetchHand();
 	}, [dispatch]);

--- a/frontend/src/mocks/handlers.js
+++ b/frontend/src/mocks/handlers.js
@@ -1,0 +1,23 @@
+// src/mocks/handlers.js
+import { rest } from 'msw';
+
+export const handlers = [
+  rest.get('/hand', (req, res, ctx) => {
+    console.log('Request intercepted:', req);
+    return res(
+      ctx.status(200),
+      ctx.json({
+        data: ['img37', 'img40', 'img72', 'img78']
+      })
+    );
+  }),
+  rest.put('/hand', (req, res, ctx) => {
+    console.log('Request intercepted:', req);
+    return res(
+      ctx.status(200),
+      ctx.json({
+        data: ['img37']
+      })
+    );
+  }),
+];

--- a/frontend/src/mocks/worker.js
+++ b/frontend/src/mocks/worker.js
@@ -1,0 +1,4 @@
+import { setupWorker } from 'msw'
+import { handlers } from './handlers'
+
+export const worker = setupWorker(...handlers);

--- a/frontend/src/services/handSlice.js
+++ b/frontend/src/services/handSlice.js
@@ -1,0 +1,26 @@
+import {createSlice} from '@reduxjs/toolkit';
+
+// Estado inicial para player
+const initialState = {
+	cards: [],
+};
+
+// Cambios de estado para player
+const handSlice = createSlice({
+	name: 'hand',
+	initialState,
+	reducers: {
+		setHand: (state, action) => {
+			state.cards = action.payload;
+		},
+		appendToHand: (state, action) => {
+			// Append the new card to the existing array of cards
+			state.cards = [...state.cards, ...action.payload];
+		},
+	},
+});
+
+// Action creators are generated for each case reducer funcion
+export const {setHand, appendToHand} = handSlice.actions;
+// return de reducer for game
+export default handSlice.reducer;

--- a/frontend/src/store/store.js
+++ b/frontend/src/store/store.js
@@ -1,10 +1,12 @@
 import {configureStore} from '@reduxjs/toolkit';
 import playerReducer from '../playerSlice.js';
+import handReducer from '../services/handSlice.js';
 
 // configuracion de los estados y sus reducers
 const store = configureStore({
 	reducer: {
 		player: playerReducer,
+		hand: handReducer,
 	},
 });
 


### PR DESCRIPTION
Refactoricé Hand para que use redux para el manejo de estados, creando slice, reducers y actions correspondientes.

Implementé el Deck, que utiliza redux para modificar las cartas que contiene la mano del jugador en respuesta a un click. Se da vuelta la primera carta del mazo, se agrega a la mano del jugador y se vuelve a mostrar el mazo como el dorso de una carta.

Creé un archivo Game.jsx que se utiliza para mostrar el mazo y la mano (para usarlo como entry point cambiar el script que se carga en index.html a Game.jsx), para ver como se renderea mazo y mano. En el futuro habría que modificar esto para cambiar de página usando routers.

Configuré mock service worker (msw) para mockear las respuestas a las http requests. Funciona bien por el momento. Para agregar nuevos handlers para otras requests hay que modificar el archivo src/mocks/handlers.js
