### PR TITLE
Configuratio for testing

### DIFF
--- a/frontend/jest.config.mjs
+++ b/frontend/jest.config.mjs
@@ -3,196 +3,199 @@
  * https://jestjs.io/docs/configuration
  */
 
-/** @type {import('jest').Config} */
 const config = {
-	// All imported modules in your tests should be mocked automatically
-	// automock: false,
-
-	// Stop running tests after `n` failures
-	// bail: 0,
-
-	// The directory where Jest should store its cached dependency information
-	// cacheDirectory: "/tmp/jest_rs",
-
-	// Automatically clear mock calls, instances, contexts and results before every test
-	// clearMocks: false,
-
-	// Indicates whether the coverage information should be collected while executing the test
-	// collectCoverage: false,
-
-	// An array of glob patterns indicating a set of files for which coverage information should be collected
-	// collectCoverageFrom: undefined,
-
-	// The directory where Jest should output its coverage files
-	// coverageDirectory: undefined,
-
-	// An array of regexp pattern strings used to skip coverage collection
-	// coveragePathIgnorePatterns: [
-	//   "/node_modules/"
-	// ],
-
-	// Indicates which provider should be used to instrument code for coverage
+	collectCoverage: false,
+	collectCoverageFrom: ['src/**/*.{js,jsx}'],
 	coverageProvider: 'v8',
-
-	// A list of reporter names that Jest uses when writing coverage reports
-	// coverageReporters: [
-	//   "json",
-	//   "text",
-	//   "lcov",
-	//   "clover"
-	// ],
-
-	// An object that configures minimum threshold enforcement for coverage results
-	// coverageThreshold: undefined,
-
-	// A path to a custom dependency extractor
-	// dependencyExtractor: undefined,
-
-	// Make calling deprecated APIs throw helpful error messages
-	// errorOnDeprecated: false,
-
-	// The default configuration for fake timers
-	// fakeTimers: {
-	//   "enableGlobally": false
-	// },
-
-	// Force coverage collection from ignored files using an array of glob patterns
-	// forceCoverageMatch: [],
-
-	// A path to a module which exports an async function that is triggered once before all test suites
-	// globalSetup: undefined,
-
-	// A path to a module which exports an async function that is triggered once after all test suites
-	// globalTeardown: undefined,
-
-	// A set of global variables that need to be available in all test environments
-	// globals: {},
-
-	// The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
-	// maxWorkers: "50%",
-
-	// An array of directory names to be searched recursively up from the requiring module's location
-	// moduleDirectories: [
-	//   "node_modules"
-	// ],
-
-	// An array of file extensions your modules use
-	// moduleFileExtensions: [
-	//   "js",
-	//   "mjs",
-	//   "cjs",
-	//   "jsx",
-	//   "ts",
-	//   "tsx",
-	//   "json",
-	//   "node"
-	// ],
-
-	// A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-	// moduleNameMapper: {},
-
-	// An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
-	// modulePathIgnorePatterns: [],
-
-	// Activates notifications for test results
-	// notify: false,
-
-	// An enum that specifies notification mode. Requires { notify: true }
-	// notifyMode: "failure-change",
-
-	// A preset that is used as a base for Jest's configuration
-	// preset: undefined,
-
-	// Run tests from one or more projects
-	// projects: undefined,
-
-	// Use this configuration option to add custom reporters to Jest
-	// reporters: undefined,
-
-	// Automatically reset mock state before every test
-	// resetMocks: false,
-
-	// Reset the module registry before running each individual test
-	// resetModules: false,
-
-	// A path to a custom resolver
-	// resolver: undefined,
-
-	// Automatically restore mock state and implementation before every test
-	// restoreMocks: false,
-
-	// The root directory that Jest should scan for tests and modules within
-	// rootDir: undefined,
-
-	// A list of paths to directories that Jest should use to search for files in
-	// roots: [
-	//   "<rootDir>"
-	// ],
-
-	// Allows you to use a custom runner instead of Jest's default test runner
-	// runner: "jest-runner",
-
-	// The paths to modules that run some code to configure or set up the testing environment before each test
-	// setupFiles: [],
-
-	// A list of paths to modules that run some code to configure or set up the testing framework before each test
-	// setupFilesAfterEnv: [],
-
-	// The number of seconds after which a test is considered as slow and reported as such in the results.
-	// slowTestThreshold: 5,
-
-	// A list of paths to snapshot serializer modules Jest should use for snapshot testing
-	// snapshotSerializers: [],
-
-	// The test environment that will be used for testing
 	testEnvironment: 'jsdom',
-
-	// Options that will be passed to the testEnvironment
-	// testEnvironmentOptions: {},
-
-	// Adds a location field to test results
-	// testLocationInResults: false,
-
-	// The glob patterns Jest uses to detect test files
-	// testMatch: [
-	//   "**/__tests__/**/*.[jt]s?(x)",
-	//   "**/?(*.)+(spec|test).[tj]s?(x)"
-	// ],
-
-	// An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-	// testPathIgnorePatterns: [
-	//   "/node_modules/"
-	// ],
-
-	// The regexp pattern or array of patterns that Jest uses to detect test files
-	// testRegex: [],
-
-	// This option allows the use of a custom results processor
-	// testResultsProcessor: undefined,
-
-	// This option allows use of a custom test runner
-	// testRunner: "jest-circus/runner",
-
-	// A map from regular expressions to paths to transformers
-	// transform: undefined,
-
-	// An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
-	// transformIgnorePatterns: [
-	//   "/node_modules/",
-	//   "\\.pnp\\.[^\\/]+$"
-	// ],
-
-	// An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
-	// unmockedModulePathPatterns: undefined,
-
-	// Indicates whether each individual test should be reported during the run
-	// verbose: undefined,
-
-	// An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
-	// watchPathIgnorePatterns: [],
-
-	// Whether to use watchman for file crawling
-	// watchman: true,
+	setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
 };
 
 export default config;
+
+// All imported modules in your tests should be mocked automatically
+// automock: false,
+
+// Stop running tests after `n` failures
+// bail: 0,
+
+// The directory where Jest should store its cached dependency information
+// cacheDirectory: "/tmp/jest_rs",
+
+// Automatically clear mock calls, instances, contexts and results before every test
+// clearMocks: false,
+
+// Indicates whether the coverage information should be collected while executing the test
+// collectCoverage: false,
+
+// An array of glob patterns indicating a set of files for which coverage information should be collected
+// collectCoverageFrom: undefined,
+
+// The directory where Jest should output its coverage files
+// coverageDirectory: undefined,
+
+// An array of regexp pattern strings used to skip coverage collection
+// coveragePathIgnorePatterns: [
+//   "/node_modules/"
+// ],
+
+// Indicates which provider should be used to instrument code for coverage
+
+// A list of reporter names that Jest uses when writing coverage reports
+// coverageReporters: [
+//   "json",
+//   "text",
+//   "lcov",
+//   "clover"
+// ],
+
+// An object that configures minimum threshold enforcement for coverage results
+// coverageThreshold: undefined,
+
+// A path to a custom dependency extractor
+// dependencyExtractor: undefined,
+
+// Make calling deprecated APIs throw helpful error messages
+// errorOnDeprecated: false,
+
+// The default configuration for fake timers
+// fakeTimers: {
+//   "enableGlobally": false
+// },
+
+// Force coverage collection from ignored files using an array of glob patterns
+// forceCoverageMatch: [],
+
+// A path to a module which exports an async function that is triggered once before all test suites
+// globalSetup: undefined,
+
+// A path to a module which exports an async function that is triggered once after all test suites
+// globalTeardown: undefined,
+
+// A set of global variables that need to be available in all test environments
+// globals: {},
+
+// The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
+// maxWorkers: "50%",
+
+// An array of directory names to be searched recursively up from the requiring module's location
+// moduleDirectories: [
+//   "node_modules"
+// ],
+
+// An array of file extensions your modules use
+// moduleFileExtensions: [
+//   "js",
+//   "mjs",
+//   "cjs",
+//   "jsx",
+//   "ts",
+//   "tsx",
+//   "json",
+//   "node"
+// ],
+
+// A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
+// moduleNameMapper: {},
+
+// An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
+// modulePathIgnorePatterns: [],
+
+// Activates notifications for test results
+// notify: false,
+
+// An enum that specifies notification mode. Requires { notify: true }
+// notifyMode: "failure-change",
+
+// A preset that is used as a base for Jest's configuration
+// preset: undefined,
+
+// Run tests from one or more projects
+// projects: undefined,
+
+// Use this configuration option to add custom reporters to Jest
+// reporters: undefined,
+
+// Automatically reset mock state before every test
+// resetMocks: false,
+
+// Reset the module registry before running each individual test
+// resetModules: false,
+
+// A path to a custom resolver
+// resolver: undefined,
+
+// Automatically restore mock state and implementation before every test
+// restoreMocks: false,
+
+// The root directory that Jest should scan for tests and modules within
+// rootDir: undefined,
+
+// A list of paths to directories that Jest should use to search for files in
+// roots: [
+//   "<rootDir>"
+// ],
+
+// Allows you to use a custom runner instead of Jest's default test runner
+// runner: "jest-runner",
+
+// The paths to modules that run some code to configure or set up the testing environment before each test
+// setupFiles: [],
+
+// A list of paths to modules that run some code to configure or set up the testing framework before each test
+// setupFilesAfterEnv: [],
+
+// The number of seconds after which a test is considered as slow and reported as such in the results.
+// slowTestThreshold: 5,
+
+// A list of paths to snapshot serializer modules Jest should use for snapshot testing
+// snapshotSerializers: [],
+
+// The test environment that will be used for testing
+
+// Options that will be passed to the testEnvironment
+// testEnvironmentOptions: {},
+
+// Adds a location field to test results
+// testLocationInResults: false,
+
+// The glob patterns Jest uses to detect test files
+// testMatch: [
+//   "**/__tests__/**/*.[jt]s?(x)",
+//   "**/?(*.)+(spec|test).[tj]s?(x)"
+// ],
+
+// An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
+// testPathIgnorePatterns: [
+//   "/node_modules/"
+// ],
+
+// The regexp pattern or array of patterns that Jest uses to detect test files
+// testRegex: [],
+
+// This option allows the use of a custom results processor
+// testResultsProcessor: undefined,
+
+// This option allows use of a custom test runner
+// testRunner: "jest-circus/runner",
+
+// A map from regular expressions to paths to transformers
+// transform: undefined,
+
+// An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
+// transformIgnorePatterns: [
+//   "/node_modules/",
+//   "\\.pnp\\.[^\\/]+$"
+// ],
+
+// An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
+// unmockedModulePathPatterns: undefined,
+
+// Indicates whether each individual test should be reported during the run
+// verbose: undefined,
+
+// An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
+// watchPathIgnorePatterns: [],
+
+// Whether to use watchman for file crawling
+// watchman: true,

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,17 +11,18 @@
 		"format": "prettier --write .",
 		"prepare": "cd .. && husky install frontend/.husky",
 		"test": "jest",
+		"coverage": "jest --coverage",
 		"test:watch": "npm run test -- --watch"
 	},
 	"dependencies": {
+		"@chakra-ui/react": "^2.8.1",
 		"@mui/material": "^5.14.9",
 		"@reduxjs/toolkit": "^1.9.6",
 		"axios": "^1.5.0",
 		"formik": "^2.4.5",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"react-redux": "^8.1.2",
-		"@chakra-ui/react": "^2.8.1"
+		"react-redux": "^8.1.2"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.22.20",
@@ -37,6 +38,7 @@
 		"eslint": "^8.49.0",
 		"eslint-config-prettier": "^9.0.0",
 		"eslint-config-standard": "^17.1.0",
+		"eslint-plugin-jest-dom": "^5.1.0",
 		"eslint-plugin-react": "^7.32.2",
 		"eslint-plugin-react-hooks": "^4.6.0",
 		"eslint-plugin-react-refresh": "^0.4.3",

--- a/frontend/src/components/FinishGame/GameHistory.jsx
+++ b/frontend/src/components/FinishGame/GameHistory.jsx
@@ -40,7 +40,7 @@ export const GameHistory = () => {
 				{longListOfPlayers.map((player) => {
 					return player.isAlive ? (
 						<Box key={player.id}>
-							<Heading size='xs'>{player.name}</Heading>
+							<Heading size='xs'>Player: {player.name}</Heading>
 							<Text>Won the game.</Text>
 						</Box>
 					) : (

--- a/frontend/src/components/FinishGame/GameHistory.test.jsx
+++ b/frontend/src/components/FinishGame/GameHistory.test.jsx
@@ -1,0 +1,17 @@
+// eslint-disable-next-line no-unused-vars
+import React from 'react';
+import {GameHistory} from './GameHistory';
+import {render, screen} from '@testing-library/react';
+
+describe('Game History', () => {
+	test('should render the Game History component', () => {
+		render(<GameHistory />);
+		const title = screen.getByText(/Game Over/i);
+		const subTitle = screen.getByText(/Results/i);
+		const players = screen.getAllByText(/Player:*/i);
+		expect(title).toBeInTheDocument();
+		expect(subTitle).toBeInTheDocument();
+		expect(players.length).toBeGreaterThanOrEqual(4);
+		expect(players.length).toBeLessThanOrEqual(12);
+	});
+});

--- a/frontend/src/components/UserForm/UserForm.test.jsx
+++ b/frontend/src/components/UserForm/UserForm.test.jsx
@@ -1,9 +1,0 @@
-// import {UserForm} from './UserForm';
-//
-// describe('UserForm', () => {
-//	it('Should render the Form that logs the player', () => {
-//		const playerTest = {name: 'userName'};
-//		const render = UserForm;
-//	});
-// });
-//


### PR DESCRIPTION
Se elimino setupTest.js para que no interfiera con las otras configuraciones. Se lo reemplaza por jest.setup.js (tal vez hay que agregar configuracion adicional (Que estaba en setupTest.js) para que funcionen los mocks)