### PR TITLE
fix: add package to fix jest not being able to process .css imports

### DIFF
--- a/frontend/jest.config.mjs
+++ b/frontend/jest.config.mjs
@@ -9,6 +9,9 @@ const config = {
 	coverageProvider: 'v8',
 	testEnvironment: 'jsdom',
 	setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+	moduleNameMapper: {
+		'\\.(css|scss)$': 'identity-obj-proxy',
+	},
 };
 
 export default config;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
 		"prepare": "cd .. && husky install frontend/.husky",
 		"test": "jest",
 		"coverage": "jest --coverage",
-		"test:watch": "npm run test -- --watch"
+		"test:watch": "npm run test -- --watch",
+		"test:file": "jest --testPathPattern"
 	},
 	"dependencies": {
 		"@chakra-ui/react": "^2.8.1",
@@ -43,6 +44,7 @@
 		"eslint-plugin-react-hooks": "^4.6.0",
 		"eslint-plugin-react-refresh": "^0.4.3",
 		"husky": "^8.0.0",
+		"identity-obj-proxy": "^3.0.0",
 		"jest": "^29.7.0",
 		"jest-dom": "^4.0.0",
 		"jest-environment-jsdom": "^29.7.0",


### PR DESCRIPTION
Agregué un paquete (en package.json) para que jest no se queje por los imports de archivos .css y la configuración correspondiente (en jest.config.mjs).

Agregué un npm script: `npm run test:file --<filepath>` para correr un test específico (puede ser útil cuando estamos debuggeando, pero acordarse de tirar todos los tests antes de commitear)