### PR TITLE
Lcvw 64 descartar carta

### DIFF
--- a/frontend/src/appActions.js
+++ b/frontend/src/appActions.js
@@ -8,6 +8,8 @@ export const setPlayerLogedIn = createAction('player/setLogedIn');
 export const setHand = createAction('hand/setHand');
 export const appendToHand = createAction('hand/appendToHand');
 export const removeFromHand = createAction('hand/removeFromHand');
+export const selectCard = createAction('hand/selectCard');
+export const cleanSelectedCard = createAction('hand/cleanSelectedCard');
 // Play Area actions
 export const addToPlayArea = createAction('playArea/addToPlayArea');
 export const cleanPlayArea = createAction('playArea/cleanPlayArea');

--- a/frontend/src/appActions.js
+++ b/frontend/src/appActions.js
@@ -11,6 +11,9 @@ export const removeFromHand = createAction('hand/removeFromHand');
 // Play Area actions
 export const addToPlayArea = createAction('playArea/addToPlayArea');
 export const cleanPlayArea = createAction('playArea/cleanPlayArea');
+// Discard Pile actions
+export const addToDiscardPile = createAction('discardPile/addToDiscardPile');
+export const cleanDiscardPile = createAction('discardPile/cleanDiscardPile');
 // Loby actions
 export const setLobby = createAction('lobby/setLobby');
 export const appendToLobby = createAction('lobby/appendToLobby');

--- a/frontend/src/components/Card/Card.css
+++ b/frontend/src/components/Card/Card.css
@@ -11,6 +11,10 @@
 	transform: scale(1.05);
 }
 
+.card.highlighted {
+	border: 7px solid #c5e910;
+}
+
 .card-image {
 	max-width: 100%;
 	border-radius: 25px;

--- a/frontend/src/components/Card/Card.jsx
+++ b/frontend/src/components/Card/Card.jsx
@@ -2,14 +2,13 @@ import './Card.css';
 import PropTypes from 'prop-types';
 
 const backImageFromType = {
-	0: 'panic-reverse.jpg',	// panic
-	1: 'reverse.jpg', 		// stay away
-	2: 'reverse.jpg',		// infected
-	3: 'reverse.jpg', 		// it
+	0: 'panic-reverse.jpg', // panic
+	1: 'reverse.jpg', // stay away
+	2: 'reverse.jpg', // infected
+	3: 'reverse.jpg', // it
 };
 
 const Card = ({className, onClick, info, front}) => {
-
 	// Determines the image source for a card based on its front/back status.
 	const cardImageSource = (front) => {
 		if (front) {

--- a/frontend/src/components/Card/Card.jsx
+++ b/frontend/src/components/Card/Card.jsx
@@ -41,4 +41,8 @@ Card.propTypes = {
 	front: PropTypes.bool,
 };
 
+Card.defaultProps = {
+	className: 'card',
+};
+
 export default Card;

--- a/frontend/src/components/Card/Card.jsx
+++ b/frontend/src/components/Card/Card.jsx
@@ -1,3 +1,4 @@
+import './Card.css';
 import PropTypes from 'prop-types';
 
 const backImageFromType = {

--- a/frontend/src/components/DiscardPile/DiscardPile.jsx
+++ b/frontend/src/components/DiscardPile/DiscardPile.jsx
@@ -1,0 +1,51 @@
+import { Box } from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { addToDiscardPile, removeFromHand } from '../../appActions';
+import Card from '../Card/Card.jsx';
+
+const DiscardPile = () => {
+	const selectedCard = useSelector((state) => state.hand.selectedCard);
+	const discardedCard = useSelector((state) => state.discardPile.discardedCard);
+	const [highlight, setHighlight] = useState(false);
+	const dispatch = useDispatch();
+
+	/*
+		Highlight the discard pile when a card is discarded.
+	*/
+	useEffect(() => {
+		console.log('Discarded card updated: ', discardedCard);
+		setHighlight(true);
+		setTimeout(() => {
+			setHighlight(false);
+		}, 1000);
+	}, [discardedCard]);
+
+	/*
+		When the discard pile is clicked, the selected card is placed in the
+		discard pile and removed from the player's hand.
+	*/
+	const handleClick = () => {
+		console.log('Click on discard pile');
+		if (selectedCard !== '') {
+			dispatch(addToDiscardPile(selectedCard));
+			dispatch(removeFromHand(selectedCard));
+
+			console.log('Card discarded');
+		}
+	};
+
+	return (
+		<Box w='100%' h='100%' className='discard-pile' onClick={handleClick}>
+			{discardedCard && (
+				<Card
+					className={`card ${highlight ? 'highlighted' : ''}`}
+					info={discardedCard}
+					front={false}
+				/>
+			)}
+		</Box>
+	);
+};
+
+export default DiscardPile;

--- a/frontend/src/components/DiscardPile/DiscardPile.jsx
+++ b/frontend/src/components/DiscardPile/DiscardPile.jsx
@@ -1,7 +1,7 @@
-import { Box } from '@chakra-ui/react';
-import { useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { addToDiscardPile, removeFromHand } from '../../appActions';
+import {Box} from '@chakra-ui/react';
+import {useEffect, useState} from 'react';
+import {useDispatch, useSelector} from 'react-redux';
+import {addToDiscardPile, removeFromHand} from '../../appActions';
 import Card from '../Card/Card.jsx';
 
 const DiscardPile = () => {

--- a/frontend/src/components/Game/Game.jsx
+++ b/frontend/src/components/Game/Game.jsx
@@ -1,6 +1,7 @@
 import Deck from '../Deck/Deck.jsx';
 import Hand from '../Hand/Hand.jsx';
 import PlayArea from '../PlayArea/PlayArea';
+import DiscardPile from '../DiscardPile/DiscardPile';
 import Positions from './Positions.jsx';
 import {Grid, Center, Box, GridItem, Flex} from '@chakra-ui/react';
 import {useDispatch, useSelector} from 'react-redux';
@@ -74,6 +75,7 @@ const Game = () => {
 						</Box>
 						<Box w='200px' border='2px' color='black'>
 							Discard
+							<DiscardPile />
 						</Box>
 					</Flex>
 				</GridItem>

--- a/frontend/src/components/Hand/Hand.jsx
+++ b/frontend/src/components/Hand/Hand.jsx
@@ -14,7 +14,7 @@ import {
 
 // represents a player's hand
 const Hand = () => {
-	const userId = 1;
+	const userId = useSelector((state) => state.game.currentPlayer);
 	const targetId = 2;
 
 	const [selectedCard, setSelectedCard] = useState(null);
@@ -29,7 +29,8 @@ const Hand = () => {
 			dispatch(setHand(res.cards));
 		};
 		fetchHand();
-	}, [dispatch]);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
 
 	/*
 		When cards are clicked once, they get selected. If clicked again, they are played.

--- a/frontend/src/components/Hand/Hand.jsx
+++ b/frontend/src/components/Hand/Hand.jsx
@@ -1,25 +1,15 @@
 import './Hand.css';
 import Card from '../../components/Card/Card.jsx';
 import getHand from '../request/getHand';
-import playCard from '../request/playCard';
-
-import {useEffect, useState} from 'react';
+import {useEffect} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
-import {
-	setHand,
-	removeFromHand,
-	addToPlayArea,
-	cleanPlayArea,
-} from '../../appActions';
+import {setHand, selectCard, cleanSelectedCard} from '../../appActions';
 
 // represents a player's hand
 const Hand = () => {
 	const userId = useSelector((state) => state.game.currentPlayer);
-	const targetId = 2;
-
-	const [selectedCard, setSelectedCard] = useState(null);
-	// select cards state
 	const cards = useSelector((state) => state.hand.cards);
+	const selectedCard = useSelector((state) => state.hand.selectedCard);
 	const dispatch = useDispatch();
 
 	// when component mounts
@@ -33,27 +23,17 @@ const Hand = () => {
 	}, []);
 
 	/*
-		When cards are clicked once, they get selected. If clicked again, they are played.
-		Playing a card consists of removing it from the player's hand and adding it to the play area.
-		Play area gets cleaned after 1 second.
-
-		TODO: error handling. Check if player is allowed to play a card
+		Select a card if clicked for the first time.
+		Unselect if clicked twice.
 	*/
 	const handleClick = async (clickedCard) => {
-		if (selectedCard === clickedCard) {
-			const cardToken = String(clickedCard);
-			// eslint-disable-next-line no-unused-vars
-			const res = await playCard({cardToken, userId, targetId});
-
-			// resolver efectos de la jugada sobre la partida
-
-			dispatch(removeFromHand(clickedCard));
-			dispatch(addToPlayArea(clickedCard));
-			setTimeout(() => dispatch(cleanPlayArea()), 1000);
+		if (selectedCard !== clickedCard) {
+			dispatch(selectCard(clickedCard));
 		} else {
-			setSelectedCard(clickedCard);
+			dispatch(cleanSelectedCard());
 		}
 	};
+
 	// render cards in hand side by side
 
 	return (

--- a/frontend/src/components/PlayArea/PlayArea.jsx
+++ b/frontend/src/components/PlayArea/PlayArea.jsx
@@ -1,16 +1,52 @@
-import './PlayArea.css';
 import Card from '../../components/Card/Card.jsx';
-
-import {useSelector} from 'react-redux';
+import {useState} from 'react';
+import {useSelector, useDispatch} from 'react-redux';
+import {removeFromHand, addToDiscardPile} from '../../appActions';
+import playCard from '../request/playCard';
+import {Box} from '@chakra-ui/react';
 
 const PlayArea = () => {
-	const card = useSelector((state) => state.playArea.card);
+	const dispatch = useDispatch();
+
+	const selectedCard = useSelector((state) => state.hand.selectedCard);
+	const [displayCard, setDisplayCard] = useState('');
+
+	const userId = useSelector((state) => state.game.userId);
+
+	/*
+		When clicking on the play area, the selected card is played (if there is one)
+		Playing a card consists of removing it from the player's hand and adding it to the play area.
+		Play area gets cleaned after 1 second.
+
+		TODO: error handling. Check if player is allowed to play a card
+	*/
+	const handleClick = async () => {
+		console.log('Click on play area');
+
+		if (selectedCard !== '') {
+			// if card was played on the play area, then no target is selected
+			// eslint-disable-next-line no-unused-vars
+			const res = await playCard({selectedCard, userId, targetId: null});
+
+			// TODO: manage card effects: lanzallamas, vigila tus espaldas, etc.
+
+			setDisplayCard(selectedCard);
+			dispatch(removeFromHand(selectedCard));
+
+			setTimeout(() => {
+				setDisplayCard('');
+				dispatch(addToDiscardPile(selectedCard));
+			}, 1000);
+
+			console.log('Card played');
+		}
+	};
 
 	// display card in play area. If card is empty, display nothing
 	return (
-		<div className='play-area'>
-			{card !== '' && <Card info={card} front={true} />}
-		</div>
+		<Box w='100%' h='100%' className='play-area' onClick={handleClick}>
+			{displayCard && <Card info={displayCard} front={true} />}
+		</Box>
 	);
 };
 

--- a/frontend/src/components/PlayArea/PlayArea.jsx
+++ b/frontend/src/components/PlayArea/PlayArea.jsx
@@ -23,7 +23,7 @@ const PlayArea = () => {
 	const handleClick = async () => {
 		console.log('Click on play area');
 
-		if (selectedCard !== '') {
+		if (selectedCard) {
 			// if card was played on the play area, then no target is selected
 			// eslint-disable-next-line no-unused-vars
 			const res = await playCard({selectedCard, userId, targetId: null});

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -6,7 +6,6 @@ import store from './store/store.js';
 
 import {ChakraProvider, extendTheme} from '@chakra-ui/react';
 
-
 import {worker} from './mocks/worker.js';
 worker.start();
 
@@ -22,7 +21,6 @@ const theme = extendTheme({
 
 ReactDOM.createRoot(document.getElementById('root')).render(
 	<React.StrictMode>
-
 		<Provider store={store}>
 			<ChakraProvider theme={theme}>
 				<App />

--- a/frontend/src/services/discardPileSlice.js
+++ b/frontend/src/services/discardPileSlice.js
@@ -9,7 +9,6 @@ const discardPileSlice = createSlice({
 	initialState,
 	reducers: {
 		addToDiscardPile: (state, action) => {
-			console.log('Dicarded card: ', action.payload);
 			state.discardedCard = action.payload;
 		},
 		cleanDiscardPile: (state) => {

--- a/frontend/src/services/discardPileSlice.js
+++ b/frontend/src/services/discardPileSlice.js
@@ -1,0 +1,22 @@
+import {createSlice} from '@reduxjs/toolkit';
+
+const initialState = {
+	discardedCard: '',
+};
+
+const discardPileSlice = createSlice({
+	name: 'discardPile',
+	initialState,
+	reducers: {
+		addToDiscardPile: (state, action) => {
+			console.log('Dicarded card: ', action.payload);
+			state.discardedCard = action.payload;
+		},
+		cleanDiscardPile: (state) => {
+			state.discardedCard = '';
+		},
+	},
+});
+
+export const {addToDiscardPile, cleanDiscardPile} = discardPileSlice.actions;
+export default discardPileSlice.reducer;

--- a/frontend/src/services/handSlice.js
+++ b/frontend/src/services/handSlice.js
@@ -3,6 +3,7 @@ import {createSlice} from '@reduxjs/toolkit';
 // Estado inicial para player
 const initialState = {
 	cards: [],
+	selectedCard: '',
 };
 
 // Cambios de estado para player
@@ -20,6 +21,13 @@ const handSlice = createSlice({
 		removeFromHand: (state, action) => {
 			// Remove the card from the array of cards
 			state.cards = state.cards.filter((card) => card.id !== action.payload.id);
+			state.selectedCard = '';
+		},
+		selectCard: (state, action) => {
+			state.selectedCard = action.payload;
+		},
+		cleanSelectedCard: (state) => {
+			state.selectedCard = '';
 		},
 	},
 });

--- a/frontend/src/services/handSlice.js
+++ b/frontend/src/services/handSlice.js
@@ -18,8 +18,8 @@ const handSlice = createSlice({
 			// Append the new card to the existing array of cards
 			state.cards = [...state.cards, ...action.payload];
 		},
+		// Remove card from hand and clean selected card
 		removeFromHand: (state, action) => {
-			// Remove the card from the array of cards
 			state.cards = state.cards.filter((card) => card.id !== action.payload.id);
 			state.selectedCard = '';
 		},
@@ -33,6 +33,12 @@ const handSlice = createSlice({
 });
 
 // Action creators are generated for each case reducer funcion
-export const {setHand, appendToHand, removeFromHand} = handSlice.actions;
+export const {
+	setHand,
+	appendToHand,
+	removeFromHand,
+	selectCard,
+	cleanSelectedCard,
+} = handSlice.actions;
 // return de reducer for game
 export default handSlice.reducer;

--- a/frontend/src/services/playAreaSlice.js
+++ b/frontend/src/services/playAreaSlice.js
@@ -1,3 +1,4 @@
+// ! Unused file
 import {createSlice} from '@reduxjs/toolkit';
 
 const initialState = {

--- a/frontend/src/store/store.js
+++ b/frontend/src/store/store.js
@@ -2,6 +2,7 @@ import {configureStore} from '@reduxjs/toolkit';
 import playerReducer from '../playerSlice.js';
 import handReducer from '../services/handSlice.js';
 import playAreaReducer from '../services/playAreaSlice.js';
+import discardPileReducer from '../services/discardPileSlice.js';
 import gameReducer from '../services/gameSlice.js';
 import lobbyReducer from '../services/lobbySlice.js';
 
@@ -11,6 +12,7 @@ const store = configureStore({
 		player: playerReducer,
 		hand: handReducer,
 		playArea: playAreaReducer,
+		discardPile: discardPileReducer,
 		lobby: lobbyReducer,
 		game: gameReducer,
 	},


### PR DESCRIPTION
- Refactoricé Hand para que marcara las cartas seleccionadas en el store en vez de en un estado interno
- Refactoricé Hand y PlayArea para que se comportaran igual que la Discard Pile (en Hand se selecciona la carta, mientras que en el componente se resuelven los clicks)
- Implementé la discard pile, incluyendo el state management en redux
- Integré la discard pile al game layout