### PR TITLE
Lcvw 73 efectos de cartas

### DIFF
--- a/frontend/src/components/Deck/Deck.jsx
+++ b/frontend/src/components/Deck/Deck.jsx
@@ -10,7 +10,7 @@ const Deck = () => {
 	// const userId = 1;
 	// TODO: @klartz revisar cambio de linea 10 por lines 11-12
 	const gameStatus = useSelector((state) => state.game);
-	const userId = gameStatus.currentPlayerId;
+	const idPlayer = gameStatus.currentPlayer;
 
 	const [clicked, setClicked] = useState(false);
 	const [card, setCard] = useState(null);
@@ -26,7 +26,7 @@ const Deck = () => {
 	const handleClick = async () => {
 		// if it wasn't clicked already
 		if (!clicked) {
-			const res = await getCard(userId);
+			const res = await getCard({idPlayer});
 			const pickedCards = res.pickedCards[0];
 
 			// display first card

--- a/frontend/src/components/Deck/Deck.jsx
+++ b/frontend/src/components/Deck/Deck.jsx
@@ -4,6 +4,9 @@ import getCard from '../request/getCard';
 import React, {useState, useEffect} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {appendToHand} from '../../services/handSlice';
+import {addToPlayArea} from '../../appActions.js';
+
+const TYPE_PANIC = 0;
 
 const Deck = () => {
 	// userId del jugador en turno, deberíamos obtenerlo del estado de la partida
@@ -35,7 +38,11 @@ const Deck = () => {
 
 			// wait and update player's hand with picked card
 			setTimeout(() => {
-				dispatch(appendToHand([pickedCards]));
+				if (pickedCards.type === TYPE_PANIC) {
+					dispatch(addToPlayArea({card: pickedCards, target: -1}));
+				} else {
+					dispatch(appendToHand([pickedCards]));
+				}
 
 				setCard({type: res.nextCardType});
 				setDisplayFront(false);

--- a/frontend/src/components/Game/PlayerIcons.jsx
+++ b/frontend/src/components/Game/PlayerIcons.jsx
@@ -14,7 +14,7 @@ export const PlayerIcons = ({
 				size='lg'
 				key={player.id}
 				color='white'
-				bg={currentPlayerId === player.id ? 'teal.500' : 'gray.900'}
+				bg={avatarColor(currentPlayerId, player)}
 				border={myPlayerId === player.id ? '2px solid blue' : '0px'}
 			>
 				<Text fontSize='xl'>{player.name}</Text>
@@ -32,6 +32,17 @@ export const PlayerIcons = ({
 		return <>{players.slice(9, 12).map((player) => renderPlayer(player))}</>;
 	}
 	return null;
+};
+
+const avatarColor = (currentPlayerId, player) => {
+	let bgColor = 'gray.900';
+
+	if (currentPlayerId === player.id) {
+		bgColor = 'teal.500';
+	} else if (!player.is_alive) {
+		bgColor = 'red.500';
+	}
+	return bgColor;
 };
 
 PlayerIcons.propTypes = {

--- a/frontend/src/components/Game/PlayerIcons.jsx
+++ b/frontend/src/components/Game/PlayerIcons.jsx
@@ -1,5 +1,7 @@
 import {Avatar, Text} from '@chakra-ui/react';
 import PropTypes from 'prop-types';
+import {useDispatch, useSelector} from 'react-redux';
+import {addToPlayArea} from '../../appActions';
 
 export const PlayerIcons = ({
 	relativePositionToTable,
@@ -7,18 +9,43 @@ export const PlayerIcons = ({
 	currentPlayerId = 0,
 }) => {
 	const myPlayerId = JSON.parse(sessionStorage.getItem('player')).id;
+	const selectedCard = useSelector((state) => state.hand.selectedCard);
+	const dispatch = useDispatch();
+
+	/* returns true if target is adjacent to current player, false otherwise  */
+	const validTarget = (player) => {
+		const currentPlayerPosition = getPlayerPosition(players, currentPlayerId);
+		return (
+			player.position === currentPlayerPosition + 1 ||
+			player.position === currentPlayerPosition - 1
+		);
+	};
 
 	const renderPlayer = (player) => {
+		/* if a player is clicked with a card selected the card is sent to the
+		play area with the player clicked as the target */
+		const handleClick = (player) => {
+			if (selectedCard && validTarget(player)) {
+				dispatch(addToPlayArea({card: selectedCard, target: player.id}));
+			}
+		};
+
 		return (
-			<Avatar
-				size='lg'
-				key={player.id}
-				color='white'
-				bg={avatarColor(currentPlayerId, player)}
-				border={myPlayerId === player.id ? '2px solid blue' : '0px'}
+			<button
+				onClick={() => {
+					handleClick(player);
+				}}
 			>
-				<Text fontSize='xl'>{player.name}</Text>
-			</Avatar>
+				<Avatar
+					size='lg'
+					key={player.id}
+					color='white'
+					bg={avatarColor(currentPlayerId, player)}
+					border={myPlayerId === player.id ? '2px solid blue' : '0px'}
+				>
+					<Text fontSize='xl'>{player.name}</Text>
+				</Avatar>
+			</button>
 		);
 	};
 
@@ -33,6 +60,16 @@ export const PlayerIcons = ({
 	}
 	return null;
 };
+
+/* search for a player with id targetId in the players array */
+function getPlayerPosition(players, targetId) {
+	for (let i = 0; i < players.length; i++) {
+		if (players[i].id === targetId) {
+			return players[i].position;
+		}
+	}
+	return null; // if player not found
+}
 
 const avatarColor = (currentPlayerId, player) => {
 	let bgColor = 'gray.900';

--- a/frontend/src/components/Game/Positions.jsx
+++ b/frontend/src/components/Game/Positions.jsx
@@ -51,10 +51,7 @@ Positions.propTypes = {
 };
 
 function getPlayers(players) {
-	const alivePlayers = players.filter((player) => player.is_alive === true);
-	const sortedPlayers = [...alivePlayers].sort(
-		(a, b) => a.position - b.position,
-	);
+	const sortedPlayers = [...players]?.sort((a, b) => a.position - b.position);
 	return sortedPlayers;
 }
 

--- a/frontend/src/components/PlayArea/PlayArea.jsx
+++ b/frontend/src/components/PlayArea/PlayArea.jsx
@@ -11,7 +11,7 @@ const PlayArea = () => {
 	const selectedCard = useSelector((state) => state.hand.selectedCard);
 	const [displayCard, setDisplayCard] = useState('');
 
-	const userId = JSON.parse(sessionStorage.getItem('player')).id;
+	const idPlayer = JSON.parse(sessionStorage.getItem('player')).id;
 
 	/*
 		When clicking on the play area, the selected card is played (if there is one)
@@ -26,7 +26,7 @@ const PlayArea = () => {
 		if (selectedCard) {
 			// if card was played on the play area, then no target is selected
 			// eslint-disable-next-line no-unused-vars
-			const res = await playCard({selectedCard, userId, targetId: null});
+			const res = await playCard({selectedCard, idPlayer, targetId: -1});
 
 			// TODO: manage card effects: lanzallamas, vigila tus espaldas, etc.
 

--- a/frontend/src/components/request/getCard.jsx
+++ b/frontend/src/components/request/getCard.jsx
@@ -1,6 +1,6 @@
 import {v4 as uuidv4} from 'uuid';
 
-const SERVER_URL = 'https://localhost:8000/hand';
+const SERVER_URL = 'http://localhost:8000/hand';
 
 const getCard = async (idPlayer) => {
 	const parseJSONResponse = (response) => {

--- a/frontend/src/components/request/getCard.jsx
+++ b/frontend/src/components/request/getCard.jsx
@@ -2,7 +2,7 @@ import {v4 as uuidv4} from 'uuid';
 
 const SERVER_URL = 'http://localhost:8000/hand';
 
-const getCard = async (idPlayer) => {
+const getCard = async ({idPlayer}) => {
 	const parseJSONResponse = (response) => {
 		return new Promise((resolve) => {
 			response.json().then((json) => {
@@ -28,13 +28,15 @@ const getCard = async (idPlayer) => {
 			});
 		});
 	};
-
+	const bodyToSend = {
+		id_player: idPlayer,
+	};
 	const config = {
 		method: 'PUT',
 		headers: {
 			'Content-Type': 'application/json',
 		},
-		body: JSON.stringify(idPlayer),
+		body: JSON.stringify(bodyToSend),
 	};
 	return new Promise((resolve, reject) => {
 		fetch(SERVER_URL, config)

--- a/frontend/src/components/request/getCard.jsx
+++ b/frontend/src/components/request/getCard.jsx
@@ -12,8 +12,8 @@ const getCard = async (idPlayer) => {
 						ok: response.ok,
 						pickedCards: json.data.picked_cards.map((card) => ({
 							id: uuidv4(),
-							token: card[0],
-							type: card[1],
+							token: card.card_token,
+							type: card.type,
 						})),
 						nextCardType: json.data.next_card_type,
 						detail: json.detail,

--- a/frontend/src/components/request/getHand.jsx
+++ b/frontend/src/components/request/getHand.jsx
@@ -10,10 +10,10 @@ const getHand = async (idPlayer) => {
 					resolve({
 						status: response.status,
 						ok: response.ok,
-						cards: json.data.card_token.map((card) => ({
+						cards: json.data.hand.map((card) => ({
 							id: uuidv4(),
-							token: card[0],
-							type: card[1],
+							token: card.card_token,
+							type: card.type,
 						})),
 						detail: json.detail,
 					});

--- a/frontend/src/components/request/playCard.jsx
+++ b/frontend/src/components/request/playCard.jsx
@@ -1,4 +1,4 @@
-const SERVER_URL = 'https://localhost:8000/hand/play';
+const SERVER_URL = 'http://localhost:8000/hand/play';
 // Should pass an object with the idPlayer, targetId and cardToken
 const playCard = async (values) => {
 	const parseJSONResponse = (response) => {

--- a/frontend/src/components/request/playCard.jsx
+++ b/frontend/src/components/request/playCard.jsx
@@ -8,11 +8,22 @@ const playCard = async (values) => {
 					resolve({
 						status: response.status_code,
 						ok: response.ok,
-						idPlayer: json.data.id_player,
-						cardToken: json.data.card_token,
-						targetId: json.data.target_id,
-						user: json.data.user,
-						targetUser: json.data.target_user,
+						// player info
+						idPlayer: json.data.user.id,
+						playerName: json.data.user.name,
+						playerIsAlive: json.data.user.is_alive,
+						playerIsInfected: json.data.user.is_infected,
+						playerPosition: json.data.user.my_position,
+						// target player info
+						idTarget: json.data.user.id,
+						targetName: json.data.user.name,
+						targetIsAlive: json.data.user.is_alive,
+						targetIsInfected: json.data.user.is_infected,
+						targetPosition: json.data.user.my_position,
+						// game info
+						game: json.data.user.game,
+						theThingWon: json.data.the_thing_won,
+						theHumansWon: json.data.the_humans_won,
 					});
 				} else {
 					resolve({

--- a/frontend/src/components/request/playCard.jsx
+++ b/frontend/src/components/request/playCard.jsx
@@ -1,6 +1,6 @@
 const SERVER_URL = 'http://localhost:8000/hand/play';
 // Should pass an object with the idPlayer, targetId and cardToken
-const playCard = async (values) => {
+const playCard = async ({selectedCard, idPlayer, targetId}) => {
 	const parseJSONResponse = (response) => {
 		return new Promise((resolve) => {
 			response.json().then((json) => {
@@ -36,9 +36,9 @@ const playCard = async (values) => {
 		});
 	};
 	const bodyTosend = {
-		id_usuario: values.idPlayer,
-		target_id: values.targetId,
-		card_token: values.cardToken,
+		id_player: idPlayer,
+		target_id: targetId,
+		card_token: selectedCard.token,
 	};
 	const config = {
 		method: 'POST',

--- a/frontend/src/components/request/playCard.jsx
+++ b/frontend/src/components/request/playCard.jsx
@@ -1,6 +1,6 @@
 const SERVER_URL = 'http://localhost:8000/hand/play';
 // Should pass an object with the idPlayer, targetId and cardToken
-const playCard = async ({selectedCard, idPlayer, targetId}) => {
+const playCard = async ({playedCard, idPlayer, targetId}) => {
 	const parseJSONResponse = (response) => {
 		return new Promise((resolve) => {
 			response.json().then((json) => {
@@ -38,7 +38,7 @@ const playCard = async ({selectedCard, idPlayer, targetId}) => {
 	const bodyTosend = {
 		id_player: idPlayer,
 		target_id: targetId,
-		card_token: selectedCard.token,
+		card_token: playedCard.token,
 	};
 	const config = {
 		method: 'POST',

--- a/frontend/src/mocks/cardHandlers.js
+++ b/frontend/src/mocks/cardHandlers.js
@@ -1,6 +1,7 @@
 import {rest} from 'msw';
 
 export const cardHandlers = [
+	// get player's hand
 	rest.get('https://localhost:8000/hand', (req, res, ctx) => {
 		console.log('Request intercepted:', req);
 		return res(
@@ -9,17 +10,18 @@ export const cardHandlers = [
 				status: 200,
 				message: '',
 				data: {
-					card_token: [
-						['img37.jpg', 1],
-						['img40.jpg', 1],
-						['img72.jpg', 1],
-						['img78.jpg', 1],
+					hand: [
+						{card_token: 'img37.jpg', type: 1},
+						{card_token: 'img40.jpg', type: 1},
+						{card_token: 'img72.jpg', type: 1},
+						{card_token: 'img78.jpg', type: 1},
 					],
 				},
 			}),
 		);
 	}),
 
+	// pick a card from the deck
 	rest.put('https://localhost:8000/hand', (req, res, ctx) => {
 		console.log('Request intercepted:', req);
 		return res(
@@ -27,7 +29,10 @@ export const cardHandlers = [
 			ctx.json({
 				status: 'int',
 				message: 'str',
-				data: {picked_cards: [['img37.jpg', 1]], next_card_type: 0},
+				data: {
+					picked_cards: [{card_token: 'img37.jpg', type: 1}],
+					next_card_type: 0,
+				},
 			}),
 		);
 	}),

--- a/frontend/src/services/playAreaSlice.js
+++ b/frontend/src/services/playAreaSlice.js
@@ -1,8 +1,7 @@
-// ! Unused file
 import {createSlice} from '@reduxjs/toolkit';
 
 const initialState = {
-	card: '',
+	card: null, // objeto de la forma {card, target}
 };
 
 const playAreaSlice = createSlice({
@@ -13,7 +12,7 @@ const playAreaSlice = createSlice({
 			state.card = action.payload;
 		},
 		cleanPlayArea: (state) => {
-			state.card = '';
+			state.card = null;
 		},
 	},
 });


### PR DESCRIPTION
Agregué la siguiente funcionalidad:
Para jugar una carta, se selecciona la carta y luego el target (que puede ser la play area, el descarte o un jugador adyacente al que tiene el turno actualmente). Esta carta es enviada a la play area donde se resuelve su efecto.
Para el lanzallamas, si un jugador se muere cambia el color de su avatar a rojo, y para el cambio de lugar, se cambian los avatares de lugar en la mesa.

Además hice que que las cartas de pánico levantas del mazo se jueguen inmediatamente en vez de agregarse a la mano.