### PR TITLE
primera implementacion de socket.io

### DIFF
--- a/frontend/src/components/request/getGameStatus.jsx
+++ b/frontend/src/components/request/getGameStatus.jsx
@@ -1,47 +1,43 @@
-const SERVER_URL = 'http://localhost:8000/game';
+import {io} from 'socket.io-client';
 
-const getGameStatus = async (idPlayer) => {
-	const parseJSONResponse = (response) => {
-		return new Promise((resolve) => {
-			response.json().then((json) => {
-				console.log('json', json);
-				if (response.ok) {
-					resolve({
-						status: response.status,
-						ok: response.ok,
-						players: json.data.players,
-						position: json.data.my_position,
-						isFinish: json.data.game_status,
-						currentPlayerId: json.data.current_player,
-					});
-				} else {
-					resolve({
-						status: response.status,
-						ok: response.ok,
-						detail: json.detail,
-					});
-				}
-			});
-		});
-	};
-	const config = {
-		method: 'GET',
-		headers: {
-			'id-player': idPlayer,
-		},
-	};
+const SERVER_URL = 'http://localhost:8000/game'; // Note that we removed '/game' from the URL
+
+const getGameStatus = (idPlayer) => {
 	return new Promise((resolve, reject) => {
-		fetch(SERVER_URL, config)
-			.then(parseJSONResponse)
-			.then((response) => {
-				if (response.ok) {
-					return resolve(response);
-				}
-				return reject(response);
-			})
-			.catch((error) => {
-				return reject(error);
+		const socket = io(SERVER_URL);
+
+		socket.emit('getGameStatus', idPlayer);
+
+		// Set a timeout for the response. If you don't receive a response within 5 seconds, consider it an error.
+		const timeout = setTimeout(() => {
+			socket.disconnect();
+
+			// eslint-disable-next-line prefer-promise-reject-errors
+			reject({
+				status: 408, // Request Timeout HTTP status code
+				ok: false,
+				detail: 'Request timeout',
 			});
+		}, 5000);
+
+		// Listen for the response from the server
+		socket.on('getGameStatus', (response) => {
+			clearTimeout(timeout); // Clear the timeout as we've received a response
+			socket.disconnect(); // Disconnect the socket after receiving the response
+
+			// Now, you can handle the response
+			if (response.ok) {
+				resolve(response);
+			} else {
+				// eslint-disable-next-line prefer-promise-reject-errors
+				reject({
+					status: response.status,
+					ok: false,
+					detail: response.detail,
+				});
+			}
+		});
 	});
 };
+
 export default getGameStatus;


### PR DESCRIPTION
Primera idea de como creo que podriamos implementar los WS en el front para que lo revisen y chequeen si les parece bien

cambie solo la funcion que hacia el htto request para atender emitir y escuchar a un evento y devolver una promesa con el resultado que va a ser manejada como antes, me falta parsear correctamente la respuesta solo lo muestro como modelo 

Notar que si solamente modificamos las funciones que hacian http request no vamos a tener que realizar cambios en los test si estabamos mockeando estas funciones con jest