### PR TITLE
fix: extracting wrong number from card token

### DIFF
--- a/frontend/src/services/cardConditions.js
+++ b/frontend/src/services/cardConditions.js
@@ -16,7 +16,7 @@ export const requiresTarget = (cardToken) => {
    ! Van solo listadas las cartas implementadas y las de infección
 */
 const getCardName = (cardToken) => {
-	const cardID = parseInt(String(cardToken).match(/\d\d/));
+	const cardID = parseInt(String(cardToken).match(/\d+/));
 
 	switch (true) {
 		case cardID === 1:


### PR DESCRIPTION
Arregla el problema de que se pueden descartar cartas que no deberían, por ejemplo, cartas de infectado y la cosa